### PR TITLE
feat: add util types to handle readonly

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,26 @@
+import type { O } from "ts-toolbelt";
+
+/**
+ * Will make all the property present in the current and child object to be
+ * readonly version of their shelves, recursively.
+ */
+export declare type DeepReadonly<T> = T extends O.Object
+  ? {
+      readonly [P in keyof T]: DeepReadonly<T[P]>;
+    }
+  : T;
+
+/**
+ * Will make all the property present in the object to be non readonly (mutable).
+ */
+export type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
+/**
+ * Will make all the property present in the current and child object to be
+ * non readonly (mutable), recursively.
+ */
+export type DeepMutable<T> = {
+  -readonly [P in keyof T]: DeepMutable<T[P]>;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./dynamoose";
 export * from "./api-gateway";
 export * from "./transformers";
+export * from "./common";


### PR DESCRIPTION
## Overview

- Description: Added type util to make it easy to work with readonly (as const)
- Schema update type: none
- Services affected: none

## References

None

## How was this tested?

Doesn't have proper tests yet, but was tested on a few example using a temp file
